### PR TITLE
Fix typo related to non-HTTP configuration

### DIFF
--- a/confs/global/multisite-default-server.conf
+++ b/confs/global/multisite-default-server.conf
@@ -1,5 +1,5 @@
 server {
-	{% if LISTEN_HTTP == "yes" %}listen 0.0.0.0:{{ HTTP_PORT }} default_server{% endif +%};
+	{% if LISTEN_HTTP == "yes" %}listen 0.0.0.0:{{ HTTP_PORT }} default_server;{% endif +%}
 	server_name _;
 	{% if has_value("AUTO_LETS_ENCRYPT", "yes") %}include /etc/nginx/multisite-default-server-https.conf;{% endif +%}
 	include /etc/nginx/multisite-default-server-lets-encrypt-webroot.conf;


### PR DESCRIPTION
Fix typo that prevents non-HTTP configuration to be working when MULTISITE is used